### PR TITLE
Replace hardcoded database credentials with env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       postgres:
         image: postgres
         env:
+          DB_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         ports:

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,8 +19,8 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
-  user: <%= ENV.fetch("POSTGRES_USER") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
+  user: <%= ENV.fetch("POSTGRES_USER") { nil } %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,9 +18,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: localhost
-  user: caley
-  password: mypassword
+  host: <%= ENV.fetch("DB_HOST") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
+  user: <%= ENV.fetch("POSTGRES_USER") %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: <%= ENV.fetch("DB_HOST") %>
+  host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
   user: <%= ENV.fetch("POSTGRES_USER") %>
 


### PR DESCRIPTION
fixes issue #93 

Why?
- App is failing to setup/run locally because of the invalid credentials

How?
- Use the env vars defined in .env file instead