### PR TITLE
Fix: Tab Keyboard Command

### DIFF
--- a/app/javascript/controllers/root_controller.js
+++ b/app/javascript/controllers/root_controller.js
@@ -42,8 +42,12 @@ export default class extends Controller {
 
   navbarKeydown(event) {
     if(event.key === 'Tab') {
-      event.preventDefault()
-      this.nextFilter()
+      if (this.searchModalOpen || this.userModalOpen || this.userSettingsModalOpen) {
+        event.preventDefault()
+      } else {
+        event.preventDefault()
+        this.nextFilter()
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes issue #84 

Issue request two tasks

- [ ] Tab changes the filter (should already work) and changes the highlighting of the UI elements - Current code already highlights filter element on tab change so have not made any changes for this point.
- [x] The tab key should not work when another modal (like "user" or "search" modals) is open - Have handled this issue to prevent tab if modal is open.