### PR TITLE
Update user modal

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
 
   before_save :postfix_email
 
+  # TODO: We probably want to normalize this to the DB with a create/update callback
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+
   private
 
   def validate_email_format

--- a/app/views/shared/modals/_user.html.erb
+++ b/app/views/shared/modals/_user.html.erb
@@ -1,62 +1,61 @@
 <div data-menu-target="userModal"
      data-user-target="userModal"
-     class="hidden absolute bottom-16">
+     class="absolute bottom-16">
   <div class="flex justify-center w-screen">
-    <div class="w-[500px] dark:bg-neutral-800/80 backdrop-filter backdrop-blur border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-md">
+    <div class="w-[500px] dark:bg-neutral-800/80 backdrop-filter backdrop-blur border border-neutral-200 dark:border-neutral-700/70 rounded-xl shadow-md">
       <div class="">
-        <div class="p-1 border-b border-neutral-200 dark:border-neutral-700">
-          <div data-user-target="userModalItem" class="flex items-center justify-between pl-1 pr-2 py-1 text-neutral-600 dark:text-neutral-400 hover:text-black hover:bg-neutral-200 dark:bg-neutral-700/50 dark:hover:bg-neutral-700/50 rounded-lg">
+        <div class="p-0.5 border-b border-neutral-200 dark:border-neutral-700/70">
+          <div data-user-target="userModalItem"
+               data-action="click->menu#openUserSettingsModal"
+               class="flex items-center justify-between p-2 text-neutral-600 dark:text-neutral-400 hover:text-black hover:bg-neutral-200 dark:bg-neutral-700/50 dark:hover:bg-neutral-700/50 rounded-lg">
             <div class="flex items-center gap-x-1.5">
-              <div class="flex items-center justify-center w-7 h-7 bg-indigo-200 rounded-md">
-                <p class="text-sm font-medium text-neutral-900"><%= current_user.workspaces.first.name.first %></p>
+              <div class="flex items-center justify-center w-5 h-5 bg-black dark:bg-white rounded-full">
+                <p class="text-xs font-medium text-white dark:text-neutral-900"><%= current_user.first_name.first %></p>
               </div>
-              <div>
-                <p class="text-[10px] font-medium"><%= current_user.workspaces.first.name %></p>
-                <p class="text-[10px] font-medium"><%= current_user.email %></p>
-              </div>
+              <p class="text-xs font-medium"><%= current_user.full_name %></p>
             </div>
             <div>
-              <div class="flex items-center justify-center w-5 h-5 hover:bg-neutral-600 rounded">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M5.62117 14.9627L6.72197 15.1351C7.53458 15.2623 8.11491 16.0066 8.05506 16.8451L7.97396 17.9816C7.95034 18.3127 8.12672 18.6244 8.41885 18.7686L9.23303 19.1697C9.52516 19.3139 9.87399 19.2599 10.1126 19.0352L10.9307 18.262C11.5339 17.6917 12.4646 17.6917 13.0685 18.262L13.8866 19.0352C14.1252 19.2608 14.4733 19.3139 14.7662 19.1697L15.5819 18.7678C15.8733 18.6244 16.0489 18.3135 16.0253 17.9833L15.9441 16.8451C15.8843 16.0066 16.4646 15.2623 17.2772 15.1351L18.378 14.9627C18.6985 14.9128 18.9568 14.6671 19.0292 14.3433L19.23 13.4428C19.3025 13.119 19.1741 12.7831 18.9064 12.5962L17.9875 11.9526C17.3095 11.4774 17.1024 10.5495 17.5119 9.82051L18.067 8.83299C18.2284 8.54543 18.2017 8.18538 17.9993 7.92602L17.4363 7.2035C17.2339 6.94413 16.8969 6.83701 16.5867 6.93447L15.5221 7.26794C14.7355 7.51441 13.8969 7.1012 13.5945 6.31908L13.1866 5.26148C13.0669 4.95218 12.7748 4.7492 12.4496 4.75L11.5472 4.75242C11.222 4.75322 10.9307 4.95782 10.8126 5.26793L10.4149 6.31344C10.1157 7.1004 9.27319 7.51683 8.4842 7.26874L7.37553 6.92078C7.0645 6.82251 6.72591 6.93044 6.52355 7.19142L5.96448 7.91474C5.76212 8.17652 5.73771 8.53738 5.90228 8.82493L6.47 9.81487C6.88812 10.5446 6.68339 11.4814 6.00149 11.9591L5.0936 12.5954C4.82588 12.7831 4.69754 13.119 4.76998 13.442L4.97077 14.3425C5.04242 14.6671 5.30069 14.9128 5.62117 14.9627Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-                  <path d="M13.5911 10.4089C14.4696 11.2875 14.4696 12.7125 13.5911 13.5911C12.7125 14.4696 11.2875 14.4696 10.4089 13.5911C9.53036 12.7125 9.53036 11.2875 10.4089 10.4089C11.2875 9.53036 12.7125 9.53036 13.5911 10.4089Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-                </svg>
-              </div>
+              <p class="text-xs font-medium text-neutral-500"><%= current_user.email_servers.count %> accounts</p>
             </div>
           </div>
         </div>
-        <div class="flex flex-col gap-y-0.5 p-1">
-          <div data-user-target="userModalItem" class="flex items-center justify-between p-2 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700/50 rounded-lg">
+        <div class="p-0.5 border-b border-neutral-200 dark:border-neutral-700/70">
+          <div class="flex flex-col gap-y-0.5">
+            <% current_user.email_servers.each do |server| %>
+              <div data-user-target="userModalItem"
+                   class="flex items-center justify-between p-2 text-neutral-600 dark:text-neutral-400 hover:text-black hover:bg-neutral-200 dark:bg-neutral-700/50 dark:hover:bg-neutral-700/50 rounded-lg">
+                <div class="flex items-center gap-x-1.5">
+                  <div class="flex items-center justify-center w-5 h-5 bg-indigo-300 rounded-full">
+                    <p class="text-xs font-medium text-neutral-900"><%= server.email.first.capitalize %></p>
+                  </div>
+                  <p class="text-xs font-medium"><%= server.email %></p>
+                </div>
+                <div>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24">
+                    <path stroke="currentColor" stroke-linecap="round" stroke-width="1.5" d="M12 5v.01m3.502.928-.005.01m2.57 2.554-.01.005m.948 3.497h-.01m-.928 3.502-.009-.005m-2.555 2.57-.005-.01M12 19v.01m-3.498-.947-.005.009m-2.555-2.57-.008.005m-.929-3.502h-.01m.947-3.498-.008-.005m2.568-2.555-.005-.008"></path>
+                  </svg>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="flex flex-col gap-y-0.5 p-0.5">
+          <div data-user-target="userModalItem" class="px-2 py-2.5 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700/50 rounded-lg">
             <div>
               <p class="text-xs font-medium">Create workspace</p>
             </div>
-            <div>
-              <div class="flex items-center justify-center w-5 h-5 bg-neutral-300 dark:bg-neutral-600 rounded">
-                <p class="text-xs font-medium text-neutral-600 dark:text-neutral-400">W</p>
-              </div>
-            </div>
           </div>
           <div data-user-target="userModalItem"
-               data-action="click->menu#openUserSettingsModal"
-               class="flex items-center justify-between p-2 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700/50 rounded-lg">
+               class="px-2 py-2.5 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700/50 rounded-lg">
             <div>
-              <p class="text-xs font-medium">User settings</p>
-            </div>
-            <div>
-              <div class="flex items-center justify-center w-5 h-5 bg-neutral-300 dark:bg-neutral-600 rounded">
-                <p class="text-xs font-medium text-neutral-600 dark:text-neutral-400">S</p>
-              </div>
+              <p class="text-xs font-medium">Add account</p>
             </div>
           </div>
           <%= button_to destroy_user_session_path, class: 'w-full', method: :delete do %>
-            <div data-user-target="userModalItem" class="logout-btn flex items-center justify-between p-2 hover:bg-red-200/20 dark:hover:bg-red-200/10 rounded-lg">
+            <div data-user-target="userModalItem"
+                 class="logout-btn flex items-center justify-between px-2 py-2.5 hover:bg-red-200/20 dark:hover:bg-red-200/10 rounded-lg">
               <div>
                 <p class="text-xs font-medium text-red-400 dark:text-red-200">Log out</p>
-              </div>
-              <div>
-                <div class="flex items-center justify-center w-5 h-5 bg-red-400/20 dark:bg-red-200/20 rounded">
-                  <p class="text-xs font-medium text-red-400 dark:text-red-200">X</p>
-                </div>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
This update defines the UI that will allow a user to filter their inbox by email account. In the future we'll be able to add email accounts and toggle them on and off in the user settings. Email accounts toggled on in the settings will appear as available in the user modal. 
<img width="578" alt="Screenshot 2024-03-05 at 9 48 20 AM" src="https://github.com/caley-io/email-rails/assets/93844519/60029b4f-c218-42f1-b495-e2ba42be7877">
