### PR TITLE
Fix Hotwire Reloading issue

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,10 @@
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    
     <%= hotwire_livereload_tags if Rails.env.development? %>
 
-    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+    <%#= turbo_refreshes_with method: :morph, scroll: :preserve %>
     <%= yield :head %>
   </head>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,5 +86,4 @@ Rails.application.configure do
 
   # Fixes Rails - Turbo - link preload but not used within a few seconds from the window's load event for CSS changes
   config.action_view.preload_links_header = false
-
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,8 @@ Rails.application.configure do
   config.hosts = nil
 
   config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+
+  # Fixes Rails - Turbo - link preload but not used within a few seconds from the window's load event for CSS changes
+  config.action_view.preload_links_header = false
+
 end


### PR DESCRIPTION
Fixes issue #99 

Followed below steps for debugging Hotwire reloading issue

- Theme not getting loaded in existing mode when we change file
On debugging on this issue, it seems like it is due to below code added in layout

`    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
`

On commenting this line, theme is getting loaded correctly in its set mode.

Also this issue on morph https://github.com/kirillplatonov/hotwire-livereload/issues/33  seems to be related.

- Tailwind changes not reflecting every time on file change

On inspecting in browser console, it seems like at times we are facing with turbo link preload issue due to which changes does not get reflected in browser. To fix this issue I have added below code in development.rb. By adding below code it does not throw now issue of "the resource  was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally"

`  config.action_view.preload_links_header = false
`

Referred this link for this issue https://stackoverflow.com/questions/72753525/rails-turbo-link-preload-but-not-used-within-a-few-seconds-from-the-windows/72901033#72901033

