### PR TITLE
#91 Custom layout for email pages.

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -1,7 +1,7 @@
 class EmailsController < ApplicationController
   before_action :authenticate_user!
   before_action :initialize_filters
-
+  layout "email", only: [ :new, :show ]
   def inbox
     # TODO: This is a temporary solution to retrieve the last 20 emails
     # TODO: Add a user setting to toggle email servers

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || "Caley.to" %></title>
+    <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Caley.to">
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <link rel="manifest" href="/manifest.json">
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+    <%= hotwire_livereload_tags if Rails.env.development? %>
+
+    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+    <%= yield :head %>
+  </head>
+
+  <body>
+    
+      <main>
+        <%= yield %>
+      </main>
+
+  </body>
+</html>


### PR DESCRIPTION
fixes issue: #91 

- [x] Create new layout called 'email'. Leave the layout empty, except for theme details that can be grabbed from application.html.erb.
- [x] Apply the layout only to the new and show actions on the emails_controller.
